### PR TITLE
fix linking against pthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,14 @@ if(${ament_cmake_FOUND})
     message(STATUS "rttest is only supported on Linux, skipping...")
     return()
   endif()
+  find_package(Threads REQUIRED)
 
   include_directories(rttest ${PROJECT_SOURCE_DIR}/include/rttest)
   add_library(rttest ${PROJECT_SOURCE_DIR}/src/rttest.cpp)
-  target_link_libraries(rttest m stdc++)
+  target_link_libraries(rttest m stdc++ ${CMAKE_THREAD_LIBS_INIT})
 
   ament_export_include_directories(include)
-  ament_export_libraries(rttest)
+  ament_export_libraries(rttest pthread)
 
   if(AMENT_ENABLE_TESTING)
     find_package(ament_cmake_gtest REQUIRED)
@@ -62,7 +63,9 @@ else()
   set(DEF_INSTALL_CMAKE_DIR lib/cmake/rttest)
   set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "install dir for cmake files")
 
+  find_package(Threads REQUIRED)
   add_library(rttest ${PROJECT_SOURCE_DIR}/src/rttest.cpp)
+  target_link_libraries(rttest m stdc++ ${CMAKE_THREAD_LIBS_INIT})
 
   include_directories(rttest ${PROJECT_SOURCE_DIR}/include/rttest)
 

--- a/rttestConfig.cmake.in
+++ b/rttestConfig.cmake.in
@@ -1,6 +1,8 @@
+find_package(Threads REQUIRED)
+
 get_filename_component(rttest_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set(rttest_INCLUDE_DIR "@rttest_INCLUDE_DIR@")
 set(rttest_INCLUDE_DIRS "${rttest_INCLUDE_DIR}")
 set(rttest_LIBRARY_DIR "@rttest_LIB_DIR@")
-set(rttest_LIBRARIES rttest m stdc++)
+set(rttest_LIBRARIES rttest m stdc++ pthread)
 set(rttest_FLAGS "-std=c++11")


### PR DESCRIPTION
This is necessary to build successful when only OpenSplice is present.

The CMakeLists.txt contains a lot of redundant code but that should be cleaned up in a separate PR.