### PR TITLE
Install rttest_plot and analyze.py as programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(${ament_cmake_FOUND})
   )
 
   install(
-    DIRECTORY scripts/
+    PROGRAMS scripts/rttest_plot
     DESTINATION bin
   )
 


### PR DESCRIPTION
Use `install(PROGRAMS...)` to install the scripts with the right permissions.

Fixes #10